### PR TITLE
add githubpages

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,3 @@
+source "https://rubygems.org"
+gem "just-the-docs"
+


### PR DESCRIPTION
Adds the "just-the-docs" gem to the Gemfile.

This sets up the project to use the Just the Docs Jekyll theme for documentation.
